### PR TITLE
automake: fix noinst_SOURCES warning

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -84,7 +84,7 @@ noinst_HEADERS=			private/cclass.h \
 				private/test-helpers.h \
 				private/utils.h
 
-noinst_SOURCES = private/cavs2c.awk
+noinst_SCRIPTS = private/cavs2c.awk
 
 if WITH_DB
 


### PR DESCRIPTION
Fix a mistake in commit 76377edd2521 ("hash functions: add tests to verify output against test vectors") when listing the cavs2c.awk script as something to not be installed.