### PR TITLE
sha2: fix incorrect sha256 hash issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,60 @@
+name: ci
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+  pull_request:
+  schedule:
+    - cron: '30 6 * * 1'
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        # The set of compilers provided in each Ubuntu version comes from:
+        #  <https://askubuntu.com/questions/466651/how-do-i-use-the-latest-gcc-on-ubuntu/1163021#1163021>
+        os: [ubuntu-22.04]
+        cc: [gcc-9, gcc-10, gcc-11, gcc-12, clang-11, clang-12, clang-13, clang-14]
+        include:
+        # Latest gcc and clang versions in Ubuntu.
+        - os: ubuntu-latest
+          cc: gcc
+        - os: ubuntu-latest
+          cc: clang
+        # Ubuntu 20.04 -- GCC 7..8 and clang 7..10.
+        # TODO: Find a nicer way to do this...
+        - os: ubuntu-20.04
+          cc: gcc-7
+        - os: ubuntu-20.04
+          cc: gcc-8
+        - os: ubuntu-20.04
+          cc: clang-7
+        - os: ubuntu-20.04
+          cc: clang-8
+        - os: ubuntu-20.04
+          cc: clang-9
+        - os: ubuntu-20.04
+          cc: clang-10
+    name: make check (${{matrix.os}}, ${{ matrix.cc }})
+    runs-on: ${{ matrix.os }}
+    env:
+      CC: ${{ matrix.cc }}
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3
+    - name: install ${{ matrix.cc }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install ${{ matrix.cc }}
+    - name: autoconf
+      run: ./autogen.sh && ./configure
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -23,9 +23,9 @@ EXTRA_libnbcompat_la_DEPENDENCIES:	$(LTLIBOBJS)
 # Test programs.
 TESTS = rmd160-test sha1-test sha2-test
 check_PROGRAMS = rmd160-test sha1-test sha2-test
-rmd160_test_LDADD = .libs/libnbcompat.a
-sha1_test_LDADD   = .libs/libnbcompat.a
-sha2_test_LDADD   = .libs/libnbcompat.a
+rmd160_test_LDADD = .libs/libnbcompat.la
+sha1_test_LDADD   = .libs/libnbcompat.la
+sha2_test_LDADD   = .libs/libnbcompat.la
 
 # It's bad form to install your "config.h", so we tweak it to make it less harmful
 install-data-hook:

--- a/configure.ac
+++ b/configure.ac
@@ -41,11 +41,17 @@ CANONICAL_HOST=$host
 AC_SUBST(CANONICAL_HOST)
 
 # Checks for programs.
+AC_LANG([C])
 AC_PROG_CC_C99
 AC_PROG_SED
 AC_PROG_INSTALL
 AC_PROG_LIBTOOL
 AC_CHECK_PROG([FIND], [find], [find])
+
+# Disable strict aliasing optimisations, as sha2.c has undefined behaviour if
+# strict aliasing is enabled. See <https://github.com/archiecobbs/libnbcompat/issues/4>.
+AS_IF([test "x$GCC" = xyes],
+  [AX_APPEND_COMPILE_FLAGS([-fno-strict-aliasing], [CFLAGS])])
 
 dnl Checks for libraries
 AC_CHECK_LIB(util, fparseln)

--- a/m4/ax_append_compile_flags.m4
+++ b/m4/ax_append_compile_flags.m4
@@ -1,0 +1,46 @@
+# ============================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_append_compile_flags.html
+# ============================================================================
+#
+# SYNOPSIS
+#
+#   AX_APPEND_COMPILE_FLAGS([FLAG1 FLAG2 ...], [FLAGS-VARIABLE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   For every FLAG1, FLAG2 it is checked whether the compiler works with the
+#   flag.  If it does, the flag is added FLAGS-VARIABLE
+#
+#   If FLAGS-VARIABLE is not specified, the current language's flags (e.g.
+#   CFLAGS) is used.  During the check the flag is always added to the
+#   current language's flags.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: This macro depends on the AX_APPEND_FLAG and
+#   AX_CHECK_COMPILE_FLAG. Please keep this macro in sync with
+#   AX_APPEND_LINK_FLAGS.
+#
+# LICENSE
+#
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 7
+
+AC_DEFUN([AX_APPEND_COMPILE_FLAGS],
+[AX_REQUIRE_DEFINED([AX_CHECK_COMPILE_FLAG])
+AX_REQUIRE_DEFINED([AX_APPEND_FLAG])
+for flag in $1; do
+  AX_CHECK_COMPILE_FLAG([$flag], [AX_APPEND_FLAG([$flag], [$2])], [], [$3], [$4])
+done
+])dnl AX_APPEND_COMPILE_FLAGS

--- a/m4/ax_append_flag.m4
+++ b/m4/ax_append_flag.m4
@@ -1,0 +1,50 @@
+# ===========================================================================
+#      https://www.gnu.org/software/autoconf-archive/ax_append_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_APPEND_FLAG(FLAG, [FLAGS-VARIABLE])
+#
+# DESCRIPTION
+#
+#   FLAG is appended to the FLAGS-VARIABLE shell variable, with a space
+#   added in between.
+#
+#   If FLAGS-VARIABLE is not specified, the current language's flags (e.g.
+#   CFLAGS) is used.  FLAGS-VARIABLE is not changed if it already contains
+#   FLAG.  If FLAGS-VARIABLE is unset in the shell, it is set to exactly
+#   FLAG.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 8
+
+AC_DEFUN([AX_APPEND_FLAG],
+[dnl
+AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_SET_IF
+AS_VAR_PUSHDEF([FLAGS], [m4_default($2,_AC_LANG_PREFIX[FLAGS])])
+AS_VAR_SET_IF(FLAGS,[
+  AS_CASE([" AS_VAR_GET(FLAGS) "],
+    [*" $1 "*], [AC_RUN_LOG([: FLAGS already contains $1])],
+    [
+     AS_VAR_APPEND(FLAGS,[" $1"])
+     AC_RUN_LOG([: FLAGS="$FLAGS"])
+    ])
+  ],
+  [
+  AS_VAR_SET(FLAGS,[$1])
+  AC_RUN_LOG([: FLAGS="$FLAGS"])
+  ])
+AS_VAR_POPDEF([FLAGS])dnl
+])dnl AX_APPEND_FLAG

--- a/m4/ax_check_compile_flag.m4
+++ b/m4/ax_check_compile_flag.m4
@@ -1,0 +1,53 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_COMPILE_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the current language's compiler
+#   or gives an error.  (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,LINK}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 6
+
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
+  ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS

--- a/m4/ax_require_defined.m4
+++ b/m4/ax_require_defined.m4
@@ -1,0 +1,37 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_require_defined.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_REQUIRE_DEFINED(MACRO)
+#
+# DESCRIPTION
+#
+#   AX_REQUIRE_DEFINED is a simple helper for making sure other macros have
+#   been defined and thus are available for use.  This avoids random issues
+#   where a macro isn't expanded.  Instead the configure script emits a
+#   non-fatal:
+#
+#     ./configure: line 1673: AX_CFLAGS_WARN_ALL: command not found
+#
+#   It's like AC_REQUIRE except it doesn't expand the required macro.
+#
+#   Here's an example:
+#
+#     AX_REQUIRE_DEFINED([AX_CHECK_LINK_FLAG])
+#
+# LICENSE
+#
+#   Copyright (c) 2014 Mike Frysinger <vapier@gentoo.org>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 2
+
+AC_DEFUN([AX_REQUIRE_DEFINED], [dnl
+  m4_ifndef([$1], [m4_fatal([macro ]$1[ is not defined; is a m4 file missing?])])
+])dnl AX_REQUIRE_DEFINED

--- a/private/cavs2c.awk
+++ b/private/cavs2c.awk
@@ -1,5 +1,5 @@
 #!/usr/bin/awk -f
-# $NetBSD: cas2c.awk,v 1.0 2023/06/06 16:12:53 cyphar Exp $
+# $NetBSD: cavs2c.awk,v 1.0 2023/06/06 16:12:53 cyphar Exp $
 
 # Copyright (c) 2023 Aleksa Sarai <cyphar@cyphar.com>.
 # All rights reserved.


### PR DESCRIPTION
As mentioned in #4, with newer GCC versions, our sha256 digest methods would
return incorrect hashes. This is due to undefined behaviour in sha2.c when
compiling with `-fstrict-aliasing` (which is implied by `-O2`, the default
compilation mode under autoconf and by most distributions).

The solution is to force autoconf to set `-fno-strict-aliasing`. In addition,
add a Github Actions workflow to run `make check` to make sure we can catch
this is if it ever happens in the future.

Fixes #4
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>